### PR TITLE
Fix port errors on Render

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,19 @@ async def remove_bg(file: UploadFile = File(...)):
     img_io.seek(0)
     return StreamingResponse(img_io, media_type="image/png")
 
+def _get_port() -> int:
+    """Return the port for the web server.
+
+    Render provides the ``PORT`` environment variable when starting the
+    service. If it is not set or is not a valid integer, fall back to 10000.
+    """
+    try:
+        return int(os.environ.get("PORT", "10000"))
+    except (TypeError, ValueError):
+        return 10000
+
+
 if __name__ == "__main__":
     import uvicorn
-    port = int(os.environ.get("PORT", 10000))  # Render sets this
-    uvicorn.run("main:app", host="0.0.0.0", port=port)
+
+    uvicorn.run("main:app", host="0.0.0.0", port=_get_port())


### PR DESCRIPTION
## Summary
- handle invalid PORT values gracefully to avoid startup errors on Render

## Testing
- `python -m py_compile main.py`
